### PR TITLE
fix: update columns dimensions for CAPO 'Collaterals Price against Price Restriction' block

### DIFF
--- a/src/components/CapoPageTable/CollateralsPriceTable.tsx
+++ b/src/components/CapoPageTable/CollateralsPriceTable.tsx
@@ -60,6 +60,7 @@ const treasuryColumns: ExtendedColumnDef<TableItem>[] = [
     accessorFn: (row) => row.collateralPrice,
     header: 'Collateral Price',
     enableSorting: true,
+    size: 215,
     cell: ({ row }) => (
       <Text size='13'>
         ${formatLargeNumber(Number(row.original.collateralPrice), 1)}
@@ -71,6 +72,7 @@ const treasuryColumns: ExtendedColumnDef<TableItem>[] = [
     accessorFn: (row) => row.priceRestriction,
     header: 'Price Restriction',
     enableSorting: true,
+    size: 215,
     cell: ({ row }) => (
       <Text size='13'>
         ${formatLargeNumber(Number(row.original.priceRestriction), 1)}
@@ -83,7 +85,7 @@ const treasuryColumns: ExtendedColumnDef<TableItem>[] = [
     header: 'Price Feed',
     enableSorting: true,
     align: 'right',
-    size: 120,
+    size: 80,
     cell: ({ row }) => {
       const explorerUrl =
         (row.original.network &&
@@ -133,10 +135,7 @@ const treasuryColumns: ExtendedColumnDef<TableItem>[] = [
           }
           side='top'
         >
-          <div
-            className='flex justify-end'
-            style={{ width: `${120}px` }}
-          >
+          <div className='flex justify-end'>
             <Text
               size='13'
               className='text-primary-11 inline-block max-w-full cursor-pointer truncate border-b border-dotted border-gray-500 leading-none'
@@ -323,6 +322,7 @@ const CollateralsPriceTable = ({
         cellClassName='py-3 px-[5px]'
         headerTextClassName='text-primary-14 font-medium'
         paginationClassName='py-0 px-[5px]'
+        tableClassName='table-fixed w-full'
       />
     </>
   );

--- a/src/shared/ui/DataTable/DataTable.tsx
+++ b/src/shared/ui/DataTable/DataTable.tsx
@@ -155,7 +155,11 @@ const DataTable = <T,>({
                           'cursor-pointer select-none',
                         headerCellClassName
                       )}
-                      style={{ width: header.column.columnDef.size }}
+                      style={{
+                        width: header.column.columnDef.size,
+                        maxWidth: header.column.columnDef.maxSize,
+                        minWidth: header.column.columnDef.minSize
+                      }}
                       onClick={
                         enableSorting
                           ? header.column.getToggleSortingHandler()
@@ -239,7 +243,11 @@ const DataTable = <T,>({
                           getAlignmentClass(columnAlign),
                           cellClassName
                         )}
-                        style={{ width: cell.column.columnDef.size }}
+                        style={{
+                          width: cell.column.columnDef.size,
+                          maxWidth: cell.column.columnDef.maxSize,
+                          minWidth: cell.column.columnDef.minSize
+                        }}
                       >
                         {flexRender(
                           cell.column.columnDef.cell,


### PR DESCRIPTION
The update includes additional ability to handle the min and max width of the table columns.