### PR TITLE
fix: update the behavior of filters for the CAPO Price Restriction

### DIFF
--- a/src/entities/Capo/CapoSpecificCollateralPrice/lib/useChartFilters.ts
+++ b/src/entities/Capo/CapoSpecificCollateralPrice/lib/useChartFilters.ts
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 
 import { NormalizedChartData } from '@/shared/types/Capo/types';
 
-type Option = {
+export type Option = {
   id: string;
   label: string;
 };
+
+export type OptionSetter = (previous: Option | null) => Option | null;
 
 const capitalizeFirstLetter = (str: string): string =>
   str.charAt(0).toUpperCase() + str.slice(1);
@@ -28,15 +30,25 @@ const findOptionById = (
 };
 
 export const useChartFilters = (rawData: NormalizedChartData[]) => {
-  const chainOptions = getOptions(rawData, 'network');
-  const collateralOptions = getOptions(rawData, 'collateral');
-
   const [selectedChain, setSelectedChain] = useState<Option | null>(null);
   const [selectedCollateral, setSelectedCollateral] = useState<Option | null>(
     null
   );
 
-  const setSelectedChainWrapper = (value: Option | null) => {
+  const chainOptions = getOptions(rawData, 'network');
+
+  const collateralOptions = getOptions(
+    rawData.filter(({ network }) => {
+      if (!selectedChain) return true;
+
+      return network === selectedChain.id;
+    }),
+    'collateral'
+  );
+
+  const setSelectedChainWrapper = (
+    value: Option | null | string | OptionSetter
+  ) => {
     if (!value) {
       setSelectedChain(null);
       return;
@@ -54,7 +66,9 @@ export const useChartFilters = (rawData: NormalizedChartData[]) => {
     }
   };
 
-  const setSelectedCollateralWrapper = (value: Option | null) => {
+  const setSelectedCollateralWrapper = (
+    value: Option | null | string | OptionSetter
+  ) => {
     if (!value) {
       setSelectedCollateral(null);
       return;

--- a/src/entities/Capo/CapoSpecificCollateralPrice/lib/useRelativeFilters.ts
+++ b/src/entities/Capo/CapoSpecificCollateralPrice/lib/useRelativeFilters.ts
@@ -1,0 +1,90 @@
+import { useEffect } from 'react';
+import { hashKey } from '@tanstack/react-query';
+
+import {
+  Option,
+  OptionSetter
+} from '@/entities/Capo/CapoSpecificCollateralPrice/lib/useChartFilters';
+
+export type UseRelativeFiltersArgs = {
+  chain: Option | null;
+  chains: Option[];
+  collaterals: Option[];
+  onChainSelect: (value: OptionSetter) => void;
+  onCollateralSelect: (value: OptionSetter) => void;
+};
+
+/**
+ * A hook for managing and updating filters of chains and collaterals (which have a close relation)
+ * in response to changes in the provided data or related filter dependencies.
+ *
+ * @param args - The arguments required to configure the hook.
+ * @param args.chains - The list of available chains to select from.
+ * @param args.collaterals - The list of available collaterals to select from.
+ * @param args.chain - The currently selected chain.
+ * @param args.onCollateralSelect - Callback function to manage collateral selection.
+ * @param args.onChainSelect - Callback function to manage chain selection.
+ *
+ * @description
+ * The hook utilizes multiple `useEffect` hooks to handle:
+ * - Selecting the first chain when no chain is selected on initialization or data change.
+ * - Selecting the first collateral when no collateral is selected on chain change.
+ * - Resetting the selected collateral if the currently selected collateral no longer exists in the list of collaterals.
+ *
+ * Dependencies like the hash key of collaterals array and mapping of the data properties
+ * are tracked to trigger effects when their values change.
+ *
+ * **IMPORTANT**
+ *
+ * This hook is designed to be used with the `useChartFilters` hook. (src/entities/Capo/CapoSpecificCollateralPrice/lib/useChartFilters.ts)
+ * So, take a look at that hook for more details on how to use this hook.
+ */
+export const useRelativeFilters = (args: UseRelativeFiltersArgs) => {
+  const { chains, collaterals, chain, onCollateralSelect, onChainSelect } =
+    args;
+
+  const chainsKey = hashKey(chains.map(({ id }) => id));
+  const collateralsKey = hashKey(collaterals.map(({ id }) => id));
+
+  useEffect(() => {
+    onChainSelect((prev) => {
+      if (prev) return prev;
+
+      const firstChain = chains[0];
+
+      if (!firstChain) return prev;
+
+      return firstChain;
+    });
+  }, [chainsKey]);
+
+  useEffect(() => {
+    onCollateralSelect((prev) => {
+      if (prev) return prev;
+
+      const firstCollateral = collaterals[0];
+
+      if (!firstCollateral) return prev;
+
+      return firstCollateral;
+    });
+  }, [chain]);
+
+  useEffect(() => {
+    onCollateralSelect((prev) => {
+      if (!prev) return prev;
+
+      const isSelectedCollateralExists = collaterals.some(
+        (option) => option.id === prev.id
+      );
+
+      if (isSelectedCollateralExists) return prev;
+
+      const firstCollateral = collaterals[0];
+
+      if (!firstCollateral) return null;
+
+      return firstCollateral;
+    });
+  }, [collateralsKey]);
+};

--- a/src/pages/CapoPage/CapoPage.tsx
+++ b/src/pages/CapoPage/CapoPage.tsx
@@ -37,7 +37,11 @@ const CapoPage = () => {
             isError={isError}
             isLoading={isLoading}
           />
-          <CapoSpecificCollateralPrice rawData={chartData} />
+          <CapoSpecificCollateralPrice
+            isError={isError}
+            isLoading={isLoading}
+            rawData={chartData}
+          />
         </div>
       </section>
     </div>

--- a/src/shared/hooks/useFiltersSync.ts
+++ b/src/shared/hooks/useFiltersSync.ts
@@ -84,7 +84,9 @@ export const useFiltersSync = <const T extends string>(
 /**This hook does the same thing as useFiltersSync, but is used for single filtering.*/
 export const useFilterSyncSingle = (
   filterId: string,
+  // TODO: has to be string (important - lead to unpredictable behaviour)
   filterValue: any,
+  // TODO: value has to be string (important - lead to unpredictable behaviour)
   setFilter: (value: any) => void
 ) => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/shared/ui/SingleSelect/SingleSelect.tsx
+++ b/src/shared/ui/SingleSelect/SingleSelect.tsx
@@ -22,6 +22,7 @@ type SingleSelectProps = {
   className?: string;
   disabled?: boolean;
   type?: string;
+  isClearable?: boolean;
 };
 
 interface CustomDropdownProps {
@@ -117,7 +118,8 @@ const SingleSelect = ({
   onChange,
   placeholder,
   className,
-  disabled
+  disabled,
+  isClearable = false
 }: SingleSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -269,7 +271,7 @@ const SingleSelect = ({
             </div>
           </View.Condition>
         </div>
-        <View.Condition if={hasSelection}>
+        <View.Condition if={hasSelection && isClearable}>
           <div
             aria-hidden='true'
             className='bg-secondary-29 h-px w-full origin-top scale-y-[.5] transform-gpu'


### PR DESCRIPTION
 Update the behavior of filters for the CAPO Price Restriction chart to stabilize the chain and collateral selection

Includes:
- Add loading and error statuses for Price Restriction block;
- Implemented logic of the relation between chain and collateral selection;
- Add ability to hide Clear button for `SingleSelect` component;
- Hidde Clear button for chain and collateral selects for Price Restriction.